### PR TITLE
Param scribble go examples

### DIFF
--- a/scribble-go/src/test/scrib/param/cgo18/AllToAll.scr
+++ b/scribble-go/src/test/scrib/param/cgo18/AllToAll.scr
@@ -1,6 +1,8 @@
 module param.cgo18.AllToAll;
 
+type <go> int from "runtime" as int;
+
 global protocol P(role A(N), role B(M))
 {
-  Msg() from A[1..N] to B[1..M];
+  Msg(int) from A[1..N] to B[1..M];
 }

--- a/scribble-go/src/test/scrib/param/cgo18/AllToAll.scr
+++ b/scribble-go/src/test/scrib/param/cgo18/AllToAll.scr
@@ -1,0 +1,6 @@
+module param.cgo18.AllToAll;
+
+global protocol P(role A(N), role B(M))
+{
+  Msg() from A[1..N] to B[1..M];
+}

--- a/scribble-go/src/test/scrib/param/cgo18/AllToOne.scr
+++ b/scribble-go/src/test/scrib/param/cgo18/AllToOne.scr
@@ -1,0 +1,6 @@
+module param.cgo18.AllToOne;
+
+global protocol P(role A(N), role B)
+{
+  Msg() from A[1..N] to B[1..1];
+}

--- a/scribble-go/src/test/scrib/param/cgo18/AllToOne.scr
+++ b/scribble-go/src/test/scrib/param/cgo18/AllToOne.scr
@@ -1,6 +1,8 @@
 module param.cgo18.AllToOne;
 
+type <go> int from "runtime" as int;
+
 global protocol P(role A(N), role B)
 {
-  Msg() from A[1..N] to B[1..1];
+  Msg(int) from A[1..N] to B[1..1];
 }

--- a/scribble-go/src/test/scrib/param/cgo18/OneToAll.scr
+++ b/scribble-go/src/test/scrib/param/cgo18/OneToAll.scr
@@ -1,6 +1,8 @@
 module param.cgo18.OneToAll;
 
+type <go> int from "runtime" as int;
+
 global protocol P(role A, role B(N))
 {
-  Msg() from A[1..1] to B[1..N];
+  Msg(int) from A[1..1] to B[1..N];
 }

--- a/scribble-go/src/test/scrib/param/cgo18/OneToAll.scr
+++ b/scribble-go/src/test/scrib/param/cgo18/OneToAll.scr
@@ -1,0 +1,6 @@
+module param.cgo18.OneToAll;
+
+global protocol P(role A, role B(N))
+{
+  Msg() from A[1..1] to B[1..N];
+}

--- a/scribble-go/src/test/scrib/param/cgo18/OneToOne.scr
+++ b/scribble-go/src/test/scrib/param/cgo18/OneToOne.scr
@@ -1,6 +1,8 @@
 module param.cgo18.OneToOne;
 
+type <go> int from "runtime" as int;
+
 global protocol P(role A, role B)
 {
-  Msg() from A[1..1] to B[1..1];
+  Msg(int) from A[1..1] to B[1..1];
 }

--- a/scribble-go/src/test/scrib/param/cgo18/OneToOne.scr
+++ b/scribble-go/src/test/scrib/param/cgo18/OneToOne.scr
@@ -1,0 +1,6 @@
+module param.cgo18.OneToOne;
+
+global protocol P(role A, role B)
+{
+  Msg() from A[1..1] to B[1..1];
+}


### PR DESCRIPTION
Parameterised Scribble protocol and their possible pairings.
Some of the are pairings are subsumed by others (in terms of runtime support) but listed them here for completeness and for testing.