### PR TITLE
Register implementation with role definition.

### DIFF
--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTApiGenConstants.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTApiGenConstants.java
@@ -24,7 +24,7 @@ public class ParamCoreSTApiGenConstants
 	public static final String GO_FINALISER_TYPE = "session.Finaliser";  // net.MPSTEndpoint;
 	
 	public static final String GO_ROLE_TYPE = "session.Role";
-	public static final String GO_ROLE_CONSTRUCTOR = "session.NewRole";
+	public static final String GO_ROLE_CONSTRUCTOR = "session.NewPRole";
 
 	public static final String GO_PARAMROLE_TYPE = "session.ParamRole";
 

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTSessionApiBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTSessionApiBuilder.java
@@ -144,6 +144,7 @@ public class ParamCoreSTSessionApiBuilder  // FIXME: make base STSessionApiBuild
 														+ ParamCoreSTStateChanApiBuilder.makeEndStateName(simpname, a) + ") {\n"
 												//+ "ep.Sub_" + actualName + " = impl\n"
 												+ "ep." + actualName + "s[i] = impl\n"
+												+ "ep.Proto."+actualName+".(session.ParamRole).Register(i)\n"
 												+ "}\n";
 							  }).collect(Collectors.joining(""));
 				}).collect(Collectors.joining(""));


### PR DESCRIPTION
A new sub-role is added when a new implementation is registered at index i.
Also updates to use Param Role constructor for gradual construction of Role.

After registration, the role will know how many connections to create with the opposite side, and the value many be used to check the total number of spawns are correct.