### PR TITLE
Fix label send

### DIFF
--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTSendActionBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTSendActionBuilder.java
@@ -71,15 +71,15 @@ public class ParamCoreSTSendActionBuilder extends STSendActionBuilder
 				throw new RuntimeException("[param-core] TODO: " + e);
 			}
 		};
-		return 
-				  "lbl := make([][]byte, " + foo.apply(g.end) + "-" + foo.apply(g.start) + "+1)\n"
-				+ "for range lbl {\n"
-				+ "lbl = append(lbl, []byte(\"" + a.mid + "\"))\n"
-				+	"}\n"
+		return
+				  "labels := make([][]byte, " + foo.apply(g.end) + "-" + foo.apply(g.start) + "+1)\n"
+				+ "for i := " + foo.apply(g.start) + "; i <=" + foo.apply(g.end) + "; i++ {\n"
+						+ "\tlabels[i-" + foo.apply(g.start) + "] = []byte(\"" + a.mid + "\")\n"
+				+ "}\n"
 				+ sEpWrite + "(" + sEpProto + "." + r.getName() + ", "
 						+ foo.apply(g.start) + ", " + foo.apply(g.end) + ", "
-						+ "lbl)\n"
-				
+						+ "labels)\n"
+
 				+ "b := make([][]byte, " + foo.apply(g.end) + "-" + foo.apply(g.start) + "+1)\n"
 				+ "for i := " + foo.apply(g.start) + "; i <= "+foo.apply(g.end)+"; i++ {\n"
 						+ "\tvar buf bytes.Buffer\n"

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTSendActionBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTSendActionBuilder.java
@@ -73,7 +73,7 @@ public class ParamCoreSTSendActionBuilder extends STSendActionBuilder
 		};
 		return
 				  "labels := make([][]byte, " + foo.apply(g.end) + "-" + foo.apply(g.start) + "+1)\n"
-				+ "for i := " + foo.apply(g.start) + "; i <=" + foo.apply(g.end) + "; i++ {\n"
+				+ "for i := " + foo.apply(g.start) + "; i <= " + foo.apply(g.end) + "; i++ {\n"
 						+ "\tlabels[i-" + foo.apply(g.start) + "] = []byte(\"" + a.mid + "\")\n"
 				+ "}\n"
 				+ sEpWrite + "(" + sEpProto + "." + r.getName() + ", "


### PR DESCRIPTION
This fixes *deadlock-like* wait behaviour at label sending (it was looping over an ever-expanding slice).
- slice should not be modified when ranging over it.
- do not use append on slices preallocated with make.
- rename lbl → labels to be clear.