### PR TITLE
Select branch fix

### DIFF
--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTBranchActionBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTBranchActionBuilder.java
@@ -101,12 +101,14 @@ public class ParamCoreSTBranchActionBuilder extends STBranchActionBuilder
 				+ "return nil\n"
 				+ "}\n"*/
 				//buildReturn(api, curr, succ);
-				
-				  "data := make([]int, " + foo.apply(g.end) + ")\n"
+				   "ch, selected := <-s._" + a.mid + "_Chan\n"
+				 + "if !selected {\n"
+                 + "\treturn nil // select ignores nilchan\n"
+                 + "}\n"
+				 + "data := make([]int, " + foo.apply(g.end) + ")\n"
 				//+ "for i := " + foo.apply(g.start) + "; i <= " + foo.apply(g.end) + "; i++ {\n"  // FIXME: num args
 						+ "var decoded int\n"
-						+ "bs, open := <-s.data\n"
-						+ "if !open { return nil } // do not select this branch. \n"
+						+ "bs := <-s.data\n"
 						+ "if err := gob.NewDecoder(bytes.NewReader(bs[0])).Decode(&decoded); err != nil {\n"
 						+	ParamCoreSTApiGenConstants.GO_IO_FUN_RECEIVER
 								+ "." + ParamCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + "." + ParamCoreSTApiGenConstants.GO_ENDPOINT_ENDPOINT
@@ -120,6 +122,6 @@ public class ParamCoreSTBranchActionBuilder extends STBranchActionBuilder
 				//+ "*arg0 = reduceFn0(data)\n"  // FIXME: arg0
 				 + "*arg0 = data[0]\n"
 				
-				+ "return s._" + a.mid + "_Chan";
+				+ "return ch";
 	}
 }

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTStateChanApiBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTStateChanApiBuilder.java
@@ -158,7 +158,7 @@ public class ParamCoreSTStateChanApiBuilder extends STStateChanApiBuilder
 						"func (" + ParamCoreSTApiGenConstants.GO_IO_FUN_RECEIVER
 								+ " *" + ab.getStateChanType(this, curr, a) + ") " + ab.getActionName(this, a) + "(" 
 								+ ab.buildArgs(a)
-								+ ") chan *" + ab.getReturnType(this, curr, succ) + " {\n"
+								+ ") <-chan *" + ab.getReturnType(this, curr, succ) + " {\n"
 					+ ab.buildBody(this, curr, a, succ) + "\n"
 					+ "}";
 		}


### PR DESCRIPTION
Select branch uses channel closing as a signal to notify Recv* functions
if their branch was selected by the message label.

- If selected, return the channel which delivers the next state.
- If not selected, return nil chan which `select` skips over.