### PR TITLE
Embed Endpoint in Role struct.

### DIFF
--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTApiGenConstants.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTApiGenConstants.java
@@ -19,7 +19,7 @@ public class ParamCoreSTApiGenConstants
 	public static final String GO_ENDPOINT_STARTPROTOCOL = "StartProtocol";
 	public static final String GO_ENDPOINT_FINISHPROTOCOL = "FinishProtocol";
 	public static final String GO_ENDPOINT_FINALISE = "Finalise";
-	public static final String GO_ENDPOINT_ENDPOINT = "Ept";
+	public static final String GO_ENDPOINT_ENDPOINT = "Endpoint";
 
 	public static final String GO_FINALISER_TYPE = "session.Finaliser";  // net.MPSTEndpoint;
 	

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTBranchActionBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTBranchActionBuilder.java
@@ -74,7 +74,7 @@ public class ParamCoreSTBranchActionBuilder extends STBranchActionBuilder
 			else if (e instanceof ParamIndexVar)
 			{
 				return ParamCoreSTApiGenConstants.GO_IO_FUN_RECEIVER + "."
-					+ ParamCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".params[\"" + e + "\"]";
+					+ ParamCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".Params[\"" + e + "\"]";
 			}
 			else
 			{

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTBranchStateBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTBranchStateBuilder.java
@@ -95,7 +95,7 @@ public class ParamCoreSTBranchStateBuilder extends STBranchStateBuilder
 			else if (e instanceof ParamIndexVar)
 			{
 				return ParamCoreSTApiGenConstants.GO_IO_FUN_RECEIVER + "."
-					+ ParamCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".params[\"" + e + "\"]";
+					+ ParamCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".Params[\"" + e + "\"]";
 			}
 			else
 			{

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTReceiveActionBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTReceiveActionBuilder.java
@@ -65,7 +65,7 @@ public class ParamCoreSTReceiveActionBuilder extends STReceiveActionBuilder
 			else if (e instanceof ParamIndexVar)
 			{
 				return ParamCoreSTApiGenConstants.GO_IO_FUN_RECEIVER + "."
-					+ ParamCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".params[\"" + e + "\"]";
+					+ ParamCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".Params[\"" + e + "\"]";
 			}
 			else
 			{

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTSendActionBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTSendActionBuilder.java
@@ -65,7 +65,7 @@ public class ParamCoreSTSendActionBuilder extends STSendActionBuilder
 			else if (e instanceof ParamIndexVar)
 			{
 				return ParamCoreSTApiGenConstants.GO_IO_FUN_RECEIVER + "."
-					+ ParamCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".params[\"" + e + "\"]";
+					+ ParamCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".Params[\"" + e + "\"]";
 			}
 			else
 			{

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTSessionApiBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype/ParamCoreSTSessionApiBuilder.java
@@ -111,9 +111,7 @@ public class ParamCoreSTSessionApiBuilder  // FIXME: make base STSessionApiBuild
 									return actualName + "s map[int] func(*" + simpname + "_" + actualName + "_1) *"  // FIXME: init statechan, factor out with makeSTStateName
 											+ ParamCoreSTStateChanApiBuilder.makeEndStateName(simpname, a) + "\n";
 							  }).collect(Collectors.joining(""))
-							+ "params map[string]int\n"
-                            + "peers map[session.Role]struct{Start int; End int}\n"
-							+ ParamCoreSTApiGenConstants.GO_ENDPOINT_ENDPOINT + " *" + ParamCoreSTApiGenConstants.GO_ENDPOINT_TYPE + "\n"
+							+ " *" + ParamCoreSTApiGenConstants.GO_ENDPOINT_TYPE + "\n"
 							+ "}\n"
 							+ "\n"
 							+ "func (p *" + simpname + ") New" + epTypeName
@@ -131,14 +129,6 @@ public class ParamCoreSTSessionApiBuilder  // FIXME: make base STSessionApiBuild
 														return actualName + "s: make(map[int] func(*" + simpname + "_" + actualName + "_1) *"  // FIXME: init statechan, factor out with makeSTStateName
 																+ ParamCoreSTStateChanApiBuilder.makeEndStateName(simpname, a) + ")";
 													}).collect(Collectors.joining(", ")) + ",\n" 
-									
-									+ "params: "
-											//+ "params,"
-											+ "map[string]int {" + vars.stream().map(v -> "\"" + v + "\": " + v).collect(Collectors.joining(", ")) + "},\n"
-											
-									+ "peers: "
-										+ "make(map[session.Role]struct{Start int; End int}),\n"
-											
 									+ ParamCoreSTApiGenConstants.GO_ENDPOINT_ENDPOINT + ": "
 											+ ParamCoreSTApiGenConstants.GO_ENDPOINT_CONSTRUCTOR + "(p, p." + r + ")}\n"
 							
@@ -160,7 +150,7 @@ public class ParamCoreSTSessionApiBuilder  // FIXME: make base STSessionApiBuild
 											}
 											else if (ee instanceof ParamIndexVar)
 											{
-												return "ep.params[\"" + ee + "\"]";
+												return "ep.Params[\"" + ee + "\"]";
 											}
 											else
 											{
@@ -168,8 +158,9 @@ public class ParamCoreSTSessionApiBuilder  // FIXME: make base STSessionApiBuild
 											}
 										};
 										return
-												  "ep.peers[p." + peer.getName() + "] = struct{Start int; End int}{" + foo.apply(g.start) + ", " + foo.apply(g.end) + "}\n"
-												+ "for i := ep.peers[p." + peer.getName() + "].Start; i <= ep.peers[p." + peer.getName() + "].End; i++ {\n"
+												  "ep.Params = map[string]int {" + vars.stream().map(v -> "\"" + v + "\": " + v).collect(Collectors.joining(", ")) + "}\n"
+												+ "ep.Peers[p." + peer.getName() + "] = struct{Start int; End int}{" + foo.apply(g.start) + ", " + foo.apply(g.end) + "}\n"
+												+ "for i := ep." + ParamCoreSTApiGenConstants.GO_ENDPOINT_ENDPOINT + ".Peers[p." + peer.getName() + "].Start; i <= ep.Peers[p." + peer.getName() + "].End; i++ {\n"
 												+ "\tp." + peer.getName() + ".(session.ParamRole).Register(i)\n"
 												+ "}\n";
 									}).collect(Collectors.joining(""))


### PR DESCRIPTION
Embedding Endpoint in Role struct allows Connect/Accept functions to be
called directly from a Role.
Also moved from Role fields to Endpoint:
- role.params into Endpoint.Params
- role.peers into Endpoint.Peers