### PR TITLE
Reduce allocation in generated API code

### DIFF
--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTApiGenConstants.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTApiGenConstants.java
@@ -60,8 +60,7 @@ public class RPCoreSTApiGenConstants
 	public static final String GO_SCHAN_END_TYPE = "End";
 	
 	public static final String GO_IO_METHOD_RECEIVER = "s";
-	public static final String GO_IO_METHOD_ERROR = "err";
-	
+
 	public static final String GO_CROSS_SPLIT_FUN_PREFIX = "Split";
 	public static final String GO_CROSS_SEND_FUN_PREFIX = "Send";
 	public static final String GO_CROSS_SEND_METHOD_ARG = "arg";

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTReceiveActionBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTReceiveActionBuilder.java
@@ -89,6 +89,11 @@ public class RPCoreSTReceiveActionBuilder extends STReceiveActionBuilder
 
 			// For payloads -- FIXME: currently hardcoded for exactly one payload
 
+			String errorField = RPCoreSTApiGenConstants.GO_IO_METHOD_RECEIVER + "."
+                                + RPCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + "."
+                                + "_" + rpapi.getSuccStateChanName(succ) + "."
+                                + RPCoreSTApiGenConstants.GO_MPCHAN_ERR;
+
 			if (a.mid.isOp())
 			{
 				if (!a.payload.elems.isEmpty())
@@ -101,11 +106,11 @@ public class RPCoreSTReceiveActionBuilder extends STReceiveActionBuilder
 					//if (!a.mid.toString().equals("")) // HACK FIXME?  // Now redundant, -param-api checks mid starts uppercase
 					{ 
 						res += "var lab interface{}\n"  // string  // var decl needed for deserialization -- FIXME?
-								+ "if err = " + sEpRecv /*+ "[i]"
+								+ "if " + errorField + " = " + sEpRecv /*+ "[i]"
 										+ "." //+ RPCoreSTApiGenConstants.GO_ENDPOINT_READALL + "(" + "&lab" + ")"
 												+ RPCoreSTApiGenConstants.GO_FORMATTER_DECODE_STRING + "()"*/
 										+ "." + RPCoreSTApiGenConstants.GO_MPCHAN_IRECV + "(\"" + peer.getName() + "\", i, &lab)" 
-										+ "; err != nil {\n"
+										+ "; " + errorField + " != nil {\n"
 								//+ "log.Fatal(err)\n"
 								//+ "return " + rpapi.makeCreateSuccStateChan(succ) + "\n"  // FIXME: disable linearity check for error chan?  Or doesn't matter -- only need to disable completion check?
 								+ rpapi.makeReturnSuccStateChan(succ) + "\n"
@@ -115,12 +120,12 @@ public class RPCoreSTReceiveActionBuilder extends STReceiveActionBuilder
 					Function<String, String> makeReceivePayType = pt -> 
 								"var tmp interface{}\n"  // var tmp needed for deserialization -- FIXME?
 							//+ (extName.startsWith("[]") ? "tmp = make(" + extName + ", len(arg0))\n" : "")  // HACK? for passthru?
-							+ "if err = " + sEpRecv /*+ "[i]"  // FIXME: use peer interval
+							+ "if " + errorField + " = " + sEpRecv /*+ "[i]"  // FIXME: use peer interval
 									+ "." //+ RPCoreSTApiGenConstants.GO_ENDPOINT_READALL + "(&tmp)"
 									+ RPCoreSTApiGenConstants.GO_FORMATTER_DECODE_INT + "()"*/
 									+ "." + RPCoreSTApiGenConstants.GO_MPCHAN_IRECV + "(\"" + peer.getName() + "\", i, &tmp)" 
 					
-							+ "; err != nil {\n"
+							+ "; " + errorField + " != nil {\n"
 							//+ "log.Fatal(err)\n"
 							//+ "return " + rpapi.makeCreateSuccStateChan(succ) + "\n"  // FIXME: disable linearity check for error chan?  Or doesn't matter -- only need to disable completion check?
 							+ rpapi.makeReturnSuccStateChan(succ) + "\n"
@@ -134,11 +139,11 @@ public class RPCoreSTReceiveActionBuilder extends STReceiveActionBuilder
 			{
 				Function<String, String> makeReceiveExtName = extName -> 
 							"var tmp " + RPCoreSTApiGenConstants.GO_SCRIBMESSAGE_TYPE + "\n"  // var tmp needed for deserialization -- FIXME?
-						+ "if err = " + sEpRecv /*+ "[i]"  // FIXME: use peer interval
+						+ "if " + errorField + " = " + sEpRecv /*+ "[i]"  // FIXME: use peer interval
 								+ RPCoreSTApiGenConstants.GO_FORMATTER_DECODE_INT + "()"*/
 								+ "." + RPCoreSTApiGenConstants.GO_MPCHAN_MRECV + "(\"" + peer.getName() + "\", i, &tmp)" 
 				
-						+ "; err != nil {\n"
+						+ "; " + errorField + " != nil {\n"
 						//+ "log.Fatal(err)\n"
 						//+ "return " + rpapi.makeCreateSuccStateChan(succ) + "\n"  // FIXME: disable linearity check for error chan?  Or doesn't matter -- only need to disable completion check?
 						+ rpapi.makeReturnSuccStateChan(succ) + "\n"

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTSendActionBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTSendActionBuilder.java
@@ -77,17 +77,22 @@ public class RPCoreSTSendActionBuilder extends STSendActionBuilder
 		String res = "for i, j := " + rpapi.generateIndexExpr(d.start) + ", 0;"
 				+ " i <= " + rpapi.generateIndexExpr(d.end)+"; i, j = i+1, j+1 {\n";
 
+		String errorField = RPCoreSTApiGenConstants.GO_IO_METHOD_RECEIVER + "."
+                            + RPCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + "."
+                            + "_" + rpapi.getSuccStateChanName(succ) + "."
+                            + RPCoreSTApiGenConstants.GO_MPCHAN_ERR;
+
 		if (a.mid.isOp())
 		{
 			// Write label
 			if (!a.mid.toString().equals("")) {  // HACK FIXME?
 				res += "op := \"" + a.mid + "\"\n"  // FIXME: API constant?
-							+ "if err = " + sEpWrite /*+ "[i]"
+							+ "if " + errorField + " = " + sEpWrite /*+ "[i]"
 							+ "." //+ RPCoreSTApiGenConstants.GO_ENDPOINT_WRITEALL
 							+ RPCoreSTApiGenConstants.GO_FORMATTER_ENCODE_STRING
 							+ "(\"" + a.mid + "\"" + ")" */
-							+ "." + RPCoreSTApiGenConstants.GO_MPCHAN_ISEND + "(\"" + r.getName() + "\", i, &op)" 
-							+ "; err != nil {\n"
+							+ "." + RPCoreSTApiGenConstants.GO_MPCHAN_ISEND + "(\"" + r.getName() + "\", i, &op)"
+							+ "; " + errorField + " != nil {\n"
 					//+ "log.Fatal(err)\n"  // FIXME
 					//+ "return " + rpapi.makeCreateSuccStateChan(succ) + "\n"  // FIXME: disable linearity check for error chan?  Or doesn't matter -- only need to disable completion check?
 					+ rpapi.makeReturnSuccStateChan(succ) + "\n"
@@ -121,10 +126,11 @@ public class RPCoreSTSendActionBuilder extends STSendActionBuilder
 							+ "; err != nil {\n"
 					+ "log.Fatal(err)\n"
 					+ "}\n";*/
-			res += "err = " + sEpWrite 
-							+ "." 
-							+ (a.mid.isOp() ? RPCoreSTApiGenConstants.GO_MPCHAN_ISEND : RPCoreSTApiGenConstants.GO_MPCHAN_MSEND)
-							+ "(\"" + r.getName() + "\", i, &arg0[j])\n";
+			res += errorField + " = "
+					+ sEpWrite
+                    + "."
+                    + (a.mid.isOp() ? RPCoreSTApiGenConstants.GO_MPCHAN_ISEND : RPCoreSTApiGenConstants.GO_MPCHAN_MSEND)
+                    + "(\"" + r.getName() + "\", i, &arg0[j])\n";
 		}
 
 		res += "}\n";

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTStateChanApiBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTStateChanApiBuilder.java
@@ -279,7 +279,7 @@ public class RPCoreSTStateChanApiBuilder extends STStateChanApiBuilder
 					+ RPCoreSTApiGenConstants.GO_IO_METHOD_RECEIVER + "." + RPCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".lin = "  // FIXME: sync
 							+ RPCoreSTApiGenConstants.GO_IO_METHOD_RECEIVER + "." + RPCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".lin + 1\n"
 					+ initState +".id = " + RPCoreSTApiGenConstants.GO_IO_METHOD_RECEIVER + "." + RPCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".lin\n"
-					+ "f(succ)\n"
+					+ "f(" + initState + ")\n"
 
 				+ "}\n"
 				//+ "return " + makeCreateSuccStateChan(s, succName) + "\n"

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTStateChanApiBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTStateChanApiBuilder.java
@@ -266,7 +266,6 @@ public class RPCoreSTStateChanApiBuilder extends STStateChanApiBuilder
 		feach += "\n"
 				+ "func (" + RPCoreSTApiGenConstants.GO_IO_METHOD_RECEIVER + " *" + scTypeName
 						+ ") Foreach(f func(*" + initName + ") " + termName + ") *" + succName + " {\n"
-						+ "var " + RPCoreSTApiGenConstants.GO_IO_METHOD_ERROR + " error\n"
 						+ "for " + p + " := " + generateIndexExpr(s.getInterval().start) + "; "  // FIXME: general interval expressions
 								+ p + " <= " + generateIndexExpr(s.getInterval().end) + "; " + p + " = " + p + " + 1 {\n"
 						//+ sEp + "." + s.getParam() + "=" + s.getParam() + "\n"  // FIXME: nested Endpoint type/struct?
@@ -409,7 +408,6 @@ public class RPCoreSTStateChanApiBuilder extends STStateChanApiBuilder
 				/*+ "atomic.AddUint64(" + RPCoreSTApiGenConstants.GO_IO_METHOD_RECEIVER + "." + RPCoreSTApiGenConstants.GO_SCHAN_ENDPOINT
 						+ "." + "lin" + ")\n"*/
 
-				+ "var " + RPCoreSTApiGenConstants.GO_IO_METHOD_ERROR + " error\n"
 				+ ab.buildBody(this, curr, a, succ) + "\n"
 				+ "}";
 	}

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTStateChanApiBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTStateChanApiBuilder.java
@@ -277,7 +277,7 @@ public class RPCoreSTStateChanApiBuilder extends STStateChanApiBuilder
 						? "f(newBranch" + initName + "(ini))\n"
 						: "f(&" + initName + "{ nil, new(" + RPCoreSTApiGenConstants.GO_LINEARRESOURCE_TYPE + "), " + sEp + " })\n")  // cf. state chan builder  // FIXME: chan struct reuse*/
 					+ RPCoreSTApiGenConstants.GO_IO_METHOD_RECEIVER + "." + RPCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".lin = "  // FIXME: sync
-							+ RPCoreSTApiGenConstants.GO_IO_METHOD_RECEIVER + "." + RPCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".lin + 1\n"
+					+ RPCoreSTApiGenConstants.GO_IO_METHOD_RECEIVER + "." + RPCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".lin + 1\n"
 					+ initState +".id = " + RPCoreSTApiGenConstants.GO_IO_METHOD_RECEIVER + "." + RPCoreSTApiGenConstants.GO_SCHAN_ENDPOINT + ".lin\n"
 					+ "f(" + initState + ")\n"
 


### PR DESCRIPTION
Use error field and successor state field directly instead of allocating a local variable.
This reduces per-API call overhead due to memory allocation.