### PR TITLE
Generate code to use symmmetric message passing runtime API.

### DIFF
--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTBranchActionBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTBranchActionBuilder.java
@@ -86,7 +86,7 @@ public class RPCoreSTBranchActionBuilder extends STBranchActionBuilder
 		if (a.mid.isOp())  // Currently, assuming all mids are Ops; else all mids are sig names
 		{
 			// Duplicated from RPCoreSTReceiveActionBuilder
-			res += "var lab interface{}\n"  // string  // cf. RPCoreSTReceiveActionBuilder // var decl needed for deserializatoin -- FIXME?
+			res += "var lab string\n" // cf. RPCoreSTReceiveActionBuilder
 					+ "if err := " + sEpRecv /*+ "[1]"  // FIXME: use peer interval
 					+ "." + RPCoreSTApiGenConstants.GO_MPCHAN_IRECV + "(" + "&lab" + ")"*/
 					+ "." + RPCoreSTApiGenConstants.GO_MPCHAN_IRECV + "(\"" + peer.getName() + "\", 1, &lab" + ")"
@@ -98,14 +98,13 @@ public class RPCoreSTBranchActionBuilder extends STBranchActionBuilder
 
 			// Switch and return Cases value
 			res += "\n"
-					+ "cast := *(lab.(*string))\n"
-					+ "switch cast {\n"
+					+ "switch lab {\n"
 					+ as.stream().map(x -> 
 								"case \"" + x.mid + "\":\n" + "return &" + RPCoreSTCaseBuilder.getOpTypeName(api, curr, x.mid)
 							//+ "{ Ept: s.Ept, Res: new(session.LinearResource) }\n"
 							+ "{" + ret + "}\n"
 						).collect(Collectors.joining(""))
-					+ "default: panic(\"Shouldn't get in here: \" + cast)\n"
+					+ "default: panic(\"Shouldn't get in here: \" + lab)\n"
 					+ "}\n"
 					+ "return nil\n";  // FIXME: panic instead
 		}

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTCaseActionBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTCaseActionBuilder.java
@@ -52,19 +52,18 @@ public class RPCoreSTCaseActionBuilder extends STCaseActionBuilder
 		
 		// Duplicated from RPCoreSTReceiveActionBuilder
 		Function<String, String> makeCaseReceive = pt -> 
-				  "var tmp interface{}\n"  // var tmp needed for deserialization -- FIXME?
 				//+ (extName.startsWith("[]") ? "tmp = make(" + extName + ", len(*arg0))\n" : "")  // HACK: []  // N.B. *arg0 matches buildArgs
-				+ "if err := " + sEpRecv /*+ "[1]"  // FIXME: use peer interval
+				  "if err := " + sEpRecv /*+ "[1]"  // FIXME: use peer interval
 						+ "." + RPCoreSTApiGenConstants.GO_MPCHAN_READALL + "(&tmp)"*/
-						+ "." + RPCoreSTApiGenConstants.GO_MPCHAN_IRECV + "(\"" + peer.getName() + "\", 1, &tmp)"
+						+ "." + RPCoreSTApiGenConstants.GO_MPCHAN_IRECV + "(\"" + peer.getName() + "\", 1, &arg0)"
 						+ "; err != nil {\n"
 				//+ "log.Fatal(err)\n"
 				//+ "return " + rpapi.makeCreateSuccStateChan(succ) + "\n"  // FIXME: disable linearity check for error chan?  Or doesn't matter -- only need to disable completion check?
 				+ rpapi.makeReturnSuccStateChan(succ) + "\n"
-				+ "}\n"
+				+ "}\n";
 				//+ "*arg0 = tmp.(" + extName + ")\n";  // N.B. *arg0 matches buildArgs
-				+ "*arg0 = *(tmp.(*" + pt + "))\n";  // Cf. RPCoreSTReceiveActionBuilder // N.B. *arg0 matches buildArgs
-		
+				//+ "*arg0 = *(tmp.(*" + pt + "))\n";  // Cf. RPCoreSTReceiveActionBuilder  // N.B. *arg0 matches buildArgs
+
 		String res = "";
 		if (a.mid.isOp())
 		{

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTSelectActionBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTSelectActionBuilder.java
@@ -100,15 +100,14 @@ public class RPCoreSTSelectActionBuilder extends STBranchActionBuilder
 					throw new RuntimeException("[rp-core] TODO: -nocopy: " + a);
 				}
 
-				res += "var tmp interface{}\n";
 				res += "if err := " + sEpRecv // + (((GoJob) api.job).noCopy ? "Raw" : "");
 								//+ "[" + RPCoreSTStateChanApiBuilder.generateIndexExpr(d.start) + "].Recv(&arg0)"
 								+ "." + RPCoreSTApiGenConstants.GO_MPCHAN_IRECV + "(\"" + peer.getName() + "\", "
-								+ rpapi.generateIndexExpr(d.start) + ", &tmp)"
+								+ rpapi.generateIndexExpr(d.start) + ", &arg0)"
 						+ "; err != nil {\n"
 						+ "log.Fatal(err)\n"
 						+ "}\n"
-						+ "*arg0 = tmp.(" + extName + ")\n"
+						//+ "*arg0 = tmp.(" + extName + ")\n"
 						+ "ch := make(chan *" + rpapi.getStateChanName(curr.getSuccessor(a)) + ", 1)\n"
 						//+ "ch <- " + rpapi.makeCreateSuccStateChan(this, curr, curr.getSuccessor(a), sEp) + "\n";
 						+ "ch <- " + rpapi.makeCreateSuccStateChan(curr.getSuccessor(a)) + "\n";

--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTSelectStateBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTSelectStateBuilder.java
@@ -100,8 +100,7 @@ public class RPCoreSTSelectStateBuilder extends STBranchStateBuilder
 		res += "\n"
 				+ "func (" + RPCoreSTApiGenConstants.GO_IO_METHOD_RECEIVER + " *" + scTypeName + ") branch() {\n"
 				+ RPCoreSTApiGenConstants.GO_IO_METHOD_RECEIVER + "." + RPCoreSTApiGenConstants.GO_SCHAN_LINEARRESOURCE
-						+ "." + RPCoreSTApiGenConstants.GO_LINEARRESOURCE_USE + "()\n"
-			  + "var tmp interface{}\n";
+						+ "." + RPCoreSTApiGenConstants.GO_LINEARRESOURCE_USE + "()\n";
 		if (((GoJob) rpapi.job).noCopy)
 		{
 			/*res += 
@@ -116,11 +115,10 @@ public class RPCoreSTSelectStateBuilder extends STBranchStateBuilder
 					 "if err := " + sEpRecv + "." /*+ RPCoreSTApiGenConstants.GO_MPCHAN_CONN_MAP + "[\"" + peer.getName() + "\"][" 
 				  		+ RPCoreSTStateChanApiBuilder.generateIndexExpr(d.start) + "].Recv(&op)*/
 							+ RPCoreSTApiGenConstants.GO_MPCHAN_IRECV + "(\"" + peer.getName() + "\", "
-				  		+ rpapi.generateIndexExpr(d.start) + ", &tmp)"
+				  		+ rpapi.generateIndexExpr(d.start) + ", &op)"
 					+ "; err != nil {\n"  // g.end = g.start -- CFSM only has ? for input
 					+ "log.Fatal(err)\n"
-					+ "}\n"
-					+ "op := tmp.(string)\n";
+					+ "}\n";
 		}
 		res+= "if " + s.getActions().stream().map(a ->
 					{


### PR DESCRIPTION
Instead of using `interface{}` to store the received value temporarily then type cast (e.g. `value = (*tmp.(*T))`), use pointer to destination variable directly, i.e. `&value`.

This patch removes declaration of `var tmp interface{}` and the casts and replace them with the corresponding arg0/arg0[i-start]/lab for all usages of `IRecv` method calls.

This PR should be synchronised with runtime change rhu1/scribble-go-runtime#12