### PR TITLE
Fix typo.

### DIFF
--- a/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTStateChanApiBuilder.java
+++ b/scribble-go/src/main/java/org/scribble/ext/go/core/codegen/statetype3/RPCoreSTStateChanApiBuilder.java
@@ -287,7 +287,7 @@ public class RPCoreSTStateChanApiBuilder extends STStateChanApiBuilder
 			case Int:  
 			{
 				lte = " <= " + generateIndexExpr(s.getInterval().end);  
-				inc = "p+1";
+				inc = p + "+1";
 				break;
 			}
 			case IntPair:  


### PR DESCRIPTION
Fix codegen for all foreach uses in the for-loop increment section: from `I = p+1` to `I = I+1`